### PR TITLE
determine background or extension page by `this`

### DIFF
--- a/src/middleware/wer-middleware.raw.ts
+++ b/src/middleware/wer-middleware.raw.ts
@@ -11,8 +11,6 @@
     window = _window
   }
 
-  console.log('window', window);
-
   const injectionContext = this || {browser: null};
 
   (function() {


### PR DESCRIPTION
[//]: # (Briefly describe what your PR is about and/or solves.)

#### Checklist

- [x] I ran the linting and formatting tools (ESLint and Prettier)
- [ ] I added addittional tests if adding new features

Closes #28

pass `this` instead of `window` into the injection anonymous function, use `window.document` to determine whether `this` is window or not, which also infers whether the page is background or extension.