### PR TITLE
Start server only after the first emit

### DIFF
--- a/src/ExtensionReloader.ts
+++ b/src/ExtensionReloader.ts
@@ -87,7 +87,6 @@ export default class ExtensionReloaderImpl extends AbstractPluginReloader implem
 
     this._eventAPI = new CompilerEventsFacade(compiler);
     this._injector = middlewareInjector(parsedEntries, { port, reloadPage });
-    this._triggerer = changesTriggerer(port, reloadPage);
     this._eventAPI.afterOptimizeChunks((comp, chunks) => {
       comp.assets = {
         ...comp.assets,
@@ -96,6 +95,9 @@ export default class ExtensionReloaderImpl extends AbstractPluginReloader implem
     });
 
     this._eventAPI.afterEmit((comp) => {
+      // reload page after first emit
+      if (!this._triggerer) this._triggerer = changesTriggerer(port, reloadPage);
+
       const { contentOrBgChanged, onlyPageChanged } = this._whatChanged(comp.chunks, parsedEntries);
 
       if (contentOrBgChanged || onlyPageChanged) {


### PR DESCRIPTION
This is a port of the fix https://github.com/rubenspgcavalcante/webpack-extension-reloader/issues/51 from the unmaintained webpack v4 repo.

The idea is that when starting up the dev server, we shouldn't tell the browser to reload the extension until after the files have been emitted to the disk.