### PR TITLE
Always reload extension pages, ignore reloadPage

### DIFF
--- a/src/middleware/wer-middleware.raw.ts
+++ b/src/middleware/wer-middleware.raw.ts
@@ -120,7 +120,9 @@
       switch (type) {
         case SIGN_CHANGE:
           logger("Detected Changes. Reloading...");
-          reloadPage && window.location.reload();
+          // Always reload extension pages in the foreground when they change.
+          // This option doesn't make sense otherwise
+          window.location.reload();
           break;
 
         case SIGN_LOG:


### PR DESCRIPTION
This is a port of the fix https://github.com/rubenspgcavalcante/webpack-extension-reloader/issues/57 from the unmaintained webpack v4 repo.

The idea is that `reloadPage: false` should not disable page reloading on extension pages.
It should only disable page reloading for pages which been injected with a content script.