### PR TITLE
add compatibility with manifest V3

### DIFF
--- a/src/messages/errors.ts
+++ b/src/messages/errors.ts
@@ -10,4 +10,8 @@ the provided on 'manifest.json' or 'entry.background' \
 option of the plugin",
 );
 
-export const bgScriptManifestRequiredMsg = new Message(ERROR, 2, "Background script on manifest is required");
+export const bgScriptManifestRequiredMsg = new Message(
+  ERROR,
+  2,
+  "Background script or service worker on manifest is required",
+);

--- a/src/utils/manifest.ts
+++ b/src/utils/manifest.ts
@@ -16,11 +16,11 @@ export function extractEntries(
     throw new Error("Please specify the `output.filename` in your webpack config.");
   }
 
-  if (!background?.scripts) {
+  if (!(background?.scripts || background?.service_worker)) {
     throw new TypeError(bgScriptManifestRequiredMsg.get());
   }
 
-  const bgScriptFileNames = background.scripts;
+  const bgScriptFileNames = background.service_worker ? [background.service_worker] : background.scripts ?? [];
   const toRemove = (filename as string).replace("[name]", "");
 
   const bgWebpackEntry = Object.keys(webpackEntry).find((entryName) =>

--- a/typings/declarations.d.ts
+++ b/typings/declarations.d.ts
@@ -10,10 +10,7 @@ declare interface IMiddlewareTemplateParams {
   reloadPage: boolean;
 }
 
-declare type InjectMiddleware = (
-  assets: Record<string, any>,
-  chunks: Set<any>,
-) => Record<string, any>;
+declare type InjectMiddleware = (assets: Record<string, any>, chunks: Set<any>) => Record<string, any>;
 
 declare type MiddlewareInjector = (
   { background, contentScript, extensionPage }: IEntriesOption,
@@ -22,10 +19,7 @@ declare type MiddlewareInjector = (
 
 declare type Triggerer = (onlyPageChanged: boolean) => Promise<any>;
 
-declare type TriggererFactory = (
-  port: number,
-  reloadPage: boolean,
-) => Triggerer;
+declare type TriggererFactory = (port: number, reloadPage: boolean) => Triggerer;
 
 declare type VersionPair = [number | undefined, number | undefined];
 
@@ -45,13 +39,7 @@ declare type LOG_WARN = 3;
 declare type LOG_ERROR = 4;
 declare type LOG_DEBUG = 5;
 
-declare type LOG_LEVEL =
-  | LOG_NONE
-  | LOG_LOG
-  | LOG_INFO
-  | LOG_WARN
-  | LOG_ERROR
-  | LOG_DEBUG;
+declare type LOG_LEVEL = LOG_NONE | LOG_LOG | LOG_INFO | LOG_WARN | LOG_ERROR | LOG_DEBUG;
 
 declare interface IWebpackChunk {
   files: string[];

--- a/typings/declarations.d.ts
+++ b/typings/declarations.d.ts
@@ -61,12 +61,10 @@ declare interface IExtensionManifest {
   background?: {
     page?: string;
     scripts?: string[];
+    service_worker?: string;
   };
   icons?: {
     [key: string]: string;
-  };
-  browser_action?: {
-    default_popup: string;
   };
   content_scripts?: [
     {


### PR DESCRIPTION
This PR adds the compatibility with the manifest V3 without breaking the compatibility with the manifest V2.

#### Checklist

- [x] I ran the linting and formatting tools (ESLint and Prettier)
- [ ] I added addittional tests if adding new features

Closes #28 
