### PR TITLE
Change Prettier config file to prettier.config.js

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,0 @@
-{
-  "semi": true,
-  "arrowParens": "always",
-  "printWidth": 120,
-  "trailingComma": "all"
-}

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,12 @@
+// https://prettier.io/docs/en/configuration
+
+/** @type {import("prettier").Config} */
+const config = {
+  semi: true,
+  arrowParens: "always",
+  printWidth: 120,
+  trailingComma: "all",
+  endOfLine: "crlf",
+};
+
+module.exports = config;


### PR DESCRIPTION
This change enables us to use JSDoc comments to type-check the Prettier options available.
Also, set endOfLine to "crlf" because it was causing issues when running "npm run format" on Linux machine

[//]: # (Briefly describe what your PR is about and/or solves.)

#### Checklist

- [x] I ran the linting and formatting tools (ESLint and Prettier)
- [x] I added addittional tests if adding new features